### PR TITLE
Ajusta controller, configura conversor YAML, define MediaType e atual…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>

--- a/src/main/kotlin/com/example/Formula/config/WebConfig.kt
+++ b/src/main/kotlin/com/example/Formula/config/WebConfig.kt
@@ -1,19 +1,29 @@
 package com.example.Formula.config
 
+import com.example.Formula.serialization.converter.YamlJackson2HttpMessageConverter
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.MediaType
+import org.springframework.http.converter.HttpMessageConverter
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class WebConfig : WebMvcConfigurer {
 
+    private val MEDIA_TYPE_APPLICATION_YAML = MediaType.valueOf("application/x-yaml")
+
+    override fun extendMessageConverters(converters: MutableList<HttpMessageConverter<*>>) {
+        converters.add(YamlJackson2HttpMessageConverter())
+    }
+
     override fun configureContentNegotiation(configurer: ContentNegotiationConfigurer) {
-        configurer.favorParameter(false)
+        configurer
+            .favorParameter(false)
             .ignoreAcceptHeader(false)
             .useRegisteredExtensionsOnly(false)
             .defaultContentType(MediaType.APPLICATION_JSON)
             .mediaType("json", MediaType.APPLICATION_JSON)
             .mediaType("xml", MediaType.APPLICATION_XML)
+            .mediaType("x-yaml", MEDIA_TYPE_APPLICATION_YAML)
     }
 }

--- a/src/main/kotlin/com/example/Formula/controller/PersonController.kt
+++ b/src/main/kotlin/com/example/Formula/controller/PersonController.kt
@@ -2,8 +2,8 @@ package com.example.Formula.controller
 
 import com.example.Formula.data.vo.v1.PersonVO
 import com.example.Formula.service.PersonService
+import com.example.Formula.util.MediaType
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -13,37 +13,43 @@ class PersonController(
     @Autowired private val personService: PersonService
 ) {
 
-    @GetMapping("/{id}", produces = [MediaType.APPLICATION_JSON_VALUE,
-                                  MediaType.APPLICATION_XML_VALUE])
+    @GetMapping(
+        "/{id}",
+        produces = [MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_YML]
+    )
     fun findPersonById(@PathVariable id: Long): PersonVO {
         return personService.findById(id)
     }
 
-    @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE],
-                 produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE])
+    @PostMapping(
+        consumes = [MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_YML],
+        produces = [MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_YML]
+    )
     fun createPerson(@RequestBody person: PersonVO): PersonVO {
         return personService.create(person)
     }
 
-    @PutMapping("/{id}", consumes = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE],
-                                  produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE])
-    fun updatePersonById(
-        @PathVariable id: Long,
-        @RequestBody person: PersonVO
-    ): PersonVO {
+    @PutMapping(
+        "/{id}",
+        consumes = [MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_YML],
+        produces = [MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_YML]
+    )
+    fun updatePersonById(@PathVariable id: Long, @RequestBody person: PersonVO): PersonVO {
         return personService.updateById(id, person)
     }
 
-    @DeleteMapping("/{id}", produces = [MediaType.APPLICATION_JSON_VALUE,
-                                                 MediaType.APPLICATION_XML_VALUE])
+    @DeleteMapping(
+        "/{id}",
+        produces = [MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_YML]
+    )
     fun deletePersonById(@PathVariable id: Long): ResponseEntity<*> {
         personService.deleteById(id)
         return ResponseEntity.noContent().build<Any>()
     }
 
-
-    @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE,
-                            MediaType.APPLICATION_XML_VALUE])
+    @GetMapping(
+        produces = [MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_YML]
+    )
     fun findAllPerson(): List<PersonVO> {
         return personService.findAll()
     }

--- a/src/main/kotlin/com/example/Formula/data/vo/v1/PersonVO.kt
+++ b/src/main/kotlin/com/example/Formula/data/vo/v1/PersonVO.kt
@@ -20,5 +20,6 @@ data class PersonVO(
 
     @field: JsonIgnore
     var gender: String = "",
+
     var birthDay: LocalDate = LocalDate.now()
 )

--- a/src/main/kotlin/com/example/Formula/serialization/converter/YamlJackson2HttpMessageConverter.kt
+++ b/src/main/kotlin/com/example/Formula/serialization/converter/YamlJackson2HttpMessageConverter.kt
@@ -1,0 +1,17 @@
+package com.example.Formula.serialization.converter
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import org.springframework.http.MediaType
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter
+
+class YamlJackson2HttpMessageConverter : AbstractJackson2HttpMessageConverter(
+    YAMLMapper().apply {
+        registerModule(JavaTimeModule())
+        disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        setSerializationInclusion(JsonInclude.Include.NON_NULL)
+    },
+    MediaType.parseMediaType("application/x-yaml")
+)

--- a/src/main/kotlin/com/example/Formula/util/MediaType.kt
+++ b/src/main/kotlin/com/example/Formula/util/MediaType.kt
@@ -1,0 +1,7 @@
+package com.example.Formula.util
+
+object MediaType {
+    const val APPLICATION_JSON = "application/json"
+    const val APPLICATION_XML = "application/xml"
+    const val APPLICATION_YML = "application/x-yaml"
+}


### PR DESCRIPTION
Implementa suporte a YAML na API REST:

- Cria conversor customizado YamlJackson2HttpMessageConverter para serialização/deserialização YAML com suporte a java.time.LocalDate
- Configura WebConfig para registrar o conversor YAML e ajustar content negotiation
- Atualiza PersonController para suportar os media types JSON, XML e YAML via constante MediaType personalizada
- Define constantes de media types em MediaType.kt, incluindo application/x-yml
- Ajusta PersonVO para melhor serialização e uso de anotações Jackson
- Atualiza pom.xml conforme necessário para dependências
